### PR TITLE
Add Ionic to bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,9 @@
     "html5",
     "ionic"
   ],
+  "dependencies": {
+    "ionic": "^1.1.1"
+  },
   "license": "MIT",
   "private": false
 }


### PR DESCRIPTION
so that `main-bower-files` and other such dependency managers will load the script tag after `ionic.js`.
